### PR TITLE
Support multicluster kind for submariner

### DIFF
--- a/contrib/.gitignore
+++ b/contrib/.gitignore
@@ -1,2 +1,2 @@
-kind.yaml
+kind*.yaml
 

--- a/contrib/kind.yaml.j2
+++ b/contrib/kind.yaml.j2
@@ -3,8 +3,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   # the default CNI will not be installed
   disableDefaultCNI: true
-  apiServerAddress: {{ ovn_apiServerAddress | default('0.0.0.0') }}
-  apiServerPort: 11337
 {%- if net_cidr %}
   podSubnet: "{{ net_cidr }}"
 {%- endif %}
@@ -14,13 +12,19 @@ networking:
 {%- if ovn_ip_family %}
   ipFamily: {{ ovn_ip_family }}
 {%- endif %}
-featureGates:
-  SCTPSupport: true
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+      endpoint = ["http://{{ registry_ip }}:5000"]
 kubeadmConfigPatches:
 - |
   kind: ClusterConfiguration
   metadata:
     name: config
+{%- if dns_domain %}
+  networking:
+    dnsDomain: {{ dns_domain }}
+{%- endif %}
   apiServer:
     extraArgs:
       "v": "{{ cluster_log_level }}"


### PR DESCRIPTION
submariner.io enables direct networking between Pods and Services
in different Kubernetes clusters. Submariner supports OVN as a CNI
but currently `ovn-kubernetes` kind doesn't work in multi
cluster deployments.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->